### PR TITLE
refactor: use itemId versus name for key

### DIFF
--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -133,7 +133,7 @@ CreateThread(function()
 
 		for locationIndex, locationCoords in pairs(storeData.coords) do
 			if not storeData.blip.disabled then
-				local StoreBlip = AddBlipForCoord(locationCoords)
+				local StoreBlip = AddBlipForCoord(locationCoords.x, locationCoords.y, locationCoords.z)
 				SetBlipSprite(StoreBlip, storeData.blip.sprite)
 				SetBlipScale(StoreBlip, storeData.blip.scale or 0.7)
 				SetBlipDisplay(StoreBlip, 6)
@@ -181,7 +181,7 @@ CreateThread(function()
 					end
 				else
 					function createEntity()
-						Vendors[shopID .. locationIndex] = CreateObject(model, locationCoords.x, locationCoords.y, locationCoords.z - 1.03, 0, 0, 0)
+						Vendors[shopID .. locationIndex] = CreateObject(model, locationCoords.x, locationCoords.y, locationCoords.z - 1.03, false, false, false)
 						SetEntityHeading(Vendors[shopID .. locationIndex], locationCoords.w)
 						FreezeEntityPosition(Vendors[shopID .. locationIndex], true)
 					end

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -187,7 +187,7 @@ CreateThread(function()
 					end
 
 					function deleteEntity()
-						RemoveEntity(Vendors[shopID .. locationIndex])
+						DeleteEntity(Vendors[shopID .. locationIndex])
 					end
 				end
 

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -64,12 +64,12 @@ local function openShop(data)
 	end
 
 	for _, item in pairs(shopItems) do
-		local productData = PRODUCTS[shopData.shopItems][item.name]
+		local productData = PRODUCTS[shopData.shopItems][item.id]
 
-		item.label = ITEMS[item.name]?.label
-		item.weight = ITEMS[item.name]?.weight
+		item.label = productData.metadata?.label or ITEMS[item.name]?.label
+		item.weight = productData.metadata?.weight or ITEMS[item.name]?.weight
 		item.category = productData.category
-		item.imagePath = GetItemIcon(item.name)
+		item.imagePath = productData.metadata?.imageurl or GetItemIcon(item.name)
 		item.jobs = productData.jobs
 	end
 

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -225,6 +225,44 @@ CreateThread(function()
 	end
 end)
 
+-- Event handlers
+
+RegisterNetEvent('QBCore:Client:OnMoneyChange', function()
+	if not ShopOpen then return end
+	SendReactMessage("setSelfData", {
+		money = {
+			Cash = QBX.PlayerData.money.cash,
+			Bank = QBX.PlayerData.money.bank
+		},
+	})
+end)
+
+RegisterNetEvent('qbx_core:client:onSetMetaData', function(metadata)
+	if not metadata == 'licenses' or not ShopOpen then return end
+	SendReactMessage("setSelfData", {
+		licenses = QBX.PlayerData.metadata.licences
+	})
+end)
+
+RegisterNetEvent('qbx_core:client:onGroupUpdate', function()
+	if not ShopOpen then return end
+	Wait(5) -- Waiting for QBX to update job data
+	SendReactMessage("setSelfData", {
+		job = {
+			name = QBX.PlayerData.job.name,
+			grade = QBX.PlayerData.job.grade.level
+		}
+	})
+end)
+
+AddEventHandler('ox_inventory:updateInventory', function()
+	if not ShopOpen then return end
+	SendReactMessage("setSelfData", {
+		weight = exports.ox_inventory:GetPlayerWeight(),
+		maxWeight = exports.ox_inventory:GetPlayerMaxWeight()
+	})
+end)
+
 AddEventHandler('onResourceStop', function(resource)
 	if resource ~= GetCurrentResourceName() then return end
 

--- a/config/shop_items.lua
+++ b/config/shop_items.lua
@@ -1,38 +1,40 @@
 ---@class ShopItem
+---@field id? number internal id number, do not set
+---@field name string item name as referenced in ox_inventory
 ---@field price number base price of the item
 ---@field defaultStock? integer the amount of items available in the shop by default
 ---@field category? string the category of the item in the shop (e.g. 'Snacks', 'Tools', 'Firearms', 'Ammunition', 'Drinks')
 ---@field license? string the license required to purchase the item
 ---@field jobs? table<string, number> map of group names to min grade required to access the shop
----@field metadata? table | string
+---@field metadata? table | string metadata for item
 
 ---@type table<string, table<string, ShopItem>>
 return {
 	normal = {
-		water = { price = 1, defaultStock = 50, category = 'Snacks' },
-		burger = { price = 3, defaultStock = 50, category = 'Snacks' },
-		cola = { price = 3, defaultStock = 50, category = 'Snacks' },
+		{ name = 'water', price = 1, defaultStock = 50, category = 'Snacks' },
+		{ name = 'burger', price = 3, defaultStock = 50, category = 'Snacks' },
+		{ name = 'ecola', price = 3, defaultStock = 50, category = 'Snacks' },
 	},
 	liquor = {
-		water = { price = 1, defaultStock = 50, category = 'Snacks' },
-		burger = { price = 3, defaultStock = 50, category = 'Snacks' },
-		cola = { price = 3, defaultStock = 50, category = 'Snacks' },
+		{ name = 'water', price = 1, defaultStock = 50, category = 'Snacks' },
+		{ name = 'burger', price = 3, defaultStock = 50, category = 'Snacks' },
+		{ name = 'ecola', price = 3, defaultStock = 50, category = 'Snacks' },
 	},
 	hardware = {
-		lockpick = { price = 20, defaultStock = 50, category = 'Tools' },
+		{ name = 'lockpick', price = 20, defaultStock = 50, category = 'Tools' },
 	},
 	weapons = {
-		WEAPON_KNIFE = { price = 80, defaultStock = 250, category = 'Point Defense' },
-		WEAPON_BAT = { price = 45, defaultStock = 250, category = 'Point Defense' },
-		WEAPON_NIGHTSTICK = { price = 450, category = 'Point Defense' },
-		WEAPON_KNUCKLE = { price = 950, defaultStock = 250, category = 'Point Defense' },
-		WEAPON_PISTOL = { price = 2450, defaultStock = 5, license = "weapon", category = 'Firearms' },
-		WEAPON_SNSPISTOL = { price = 1850, defaultStock = 5, license = "weapon", category = 'Firearms' },
-		["ammo-9"] = { price = 4, defaultStock = 9500, license = "weapon", category = 'Ammunition' },
-		["ammo-45"] = { price = 7, defaultStock = 5500, license = "weapon", category = 'Ammunition' },
+		{ name = 'WEAPON_KNIFE', price = 80, defaultStock = 250, category = 'Point Defense' },
+		{ name = 'WEAPON_BAT', price = 45, defaultStock = 250, category = 'Point Defense' },
+		{ name = 'WEAPON_NIGHTSTICK', price = 500, category = 'Point Defense' },
+		{ name = 'WEAPON_KNUCKLE', price = 950, defaultStock = 250, category = 'Point Defense' },
+		{ name = 'WEAPON_PISTOL', price = 2450, defaultStock = 5, license = "weapon", category = 'Firearms' },
+		{ name = 'WEAPON_SNSPISTOL', price = 1850, defaultStock = 5, license = "weapon", category = 'Firearms' },
+		{ name = 'ammo-9', price = 4, defaultStock = 9500, license = "weapon", category = 'Ammunition' },
+		{ name = 'ammo-45', price = 7, defaultStock = 5500, license = "weapon", category = 'Ammunition' },
 	},
 	electronics = {
-		phone = { price = 55 },
-		radio = { price = 85 },
+		{ name = 'phone', price = 55 },
+		{ name = 'radio', price = 85 },
 	},
 }

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -111,6 +111,16 @@ lib.callback.register("EF-Shops:Server:PurchaseItems", function(source, purchase
 				TriggerClientEvent('ox_lib:notify', source, { title = "The requested amount of " .. itemData.label .. " is no longer in stock.", type = "error" })
 				goto continue
 			end
+			if shopItem.jobs then
+				if not shopItem.jobs[player.PlayerData.job.name] then
+					TriggerClientEvent('ox_lib:notify', source, { title = "You do not have the required job to purchase " .. itemData.label .. ".", type = "error" })
+					goto continue
+				end	
+				if shopItem.jobs[player.PlayerData.job.name] > player.PlayerData.job.grade.level then
+					TriggerClientEvent('ox_lib:notify', source, { title = "You do not have the required grade to purchase " .. itemData.label .. ".", type = "error" })
+					goto continue
+				end
+			end
 
 			local newIndex = #validCartItems + 1
 			validCartItems[newIndex] = mappedCartItem
@@ -156,18 +166,6 @@ lib.callback.register("EF-Shops:Server:PurchaseItems", function(source, purchase
 		if not productData then
 			lib.print.error("Invalid product: " .. item.name .. " in shop: " .. shopType)
 			goto continue
-		end
-
-		if productData.jobs then
-			if not productData.jobs[player.PlayerData.job.name] then
-				lib.print.error("Invalid job: " .. player.PlayerData.job.name .. " for product: " .. item.name .. " in shop: " .. shopType, "called by: " .. GetPlayerName(source))
-				goto continue
-			end
-
-			if productData.jobs[player.PlayerData.job.name] > player.PlayerData.job.grade.level then
-				lib.print.error("Invalid job grade: " .. player.PlayerData.job.grade.level .. " for product: " .. item.name .. " in shop: " .. shopType, "called by: " .. GetPlayerName(source))
-				goto continue
-			end
 		end
 
 		local hookResponse = TriggerEventHooks('buyItem', {

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -65,6 +65,7 @@ end
 lib.callback.register("EF-Shops:Server:PurchaseItems", function(source, purchaseData)
 	local player = exports.qbx_core:GetPlayer(source)
 	local shop = ShopData[purchaseData.shop.id][purchaseData.shop.location]
+	local shopType = purchaseData.shop.id
 
 	if not shop then
 		lib.print.error("Invalid shop: " .. purchaseData.shop.id .. " called by: " .. GetPlayerName(source))
@@ -86,35 +87,36 @@ lib.callback.register("EF-Shops:Server:PurchaseItems", function(source, purchase
 	end
 
 	local currency = purchaseData.currency
-	local mappedCartItems = mapBySubfield(purchaseData.items, "name")
+	local mappedCartItems = mapBySubfield(purchaseData.items, "id")
 	local validCartItems = {} ---@type OxItem[]
 
 	local totalPrice = 0
 	for i = 1, #shop.inventory do
 		local shopItem = shop.inventory[i]
 		local itemData = ITEMS[shopItem.name]
+		local mappedCartItem = mappedCartItems[shopItem.id]
 
-		if mappedCartItems[shopItem.name] then
+		if mappedCartItem then
 			if shopItem.license and player.PlayerData.metadata.licences[shopItem.license] ~= true then
 				TriggerClientEvent('ox_lib:notify', source, { title = "You do not have the license to purchase this item (" .. shopItem.license .. ").", type = "error" })
 				goto continue
 			end
 
-			if not exports.ox_inventory:CanCarryItem(source, shopItem.name, mappedCartItems[shopItem.name].quantity) then
+			if not exports.ox_inventory:CanCarryItem(source, shopItem.name, mappedCartItem.quantity) then
 				TriggerClientEvent('ox_lib:notify', source, { title = "You cannot carry the requested quantity of " .. itemData.label .. "s.", type = "error" })
 				goto continue
 			end
 
-			if shopItem.count and (mappedCartItems[shopItem.name].quantity > shopItem.count) then
+			if shopItem.count and (mappedCartItem.quantity > shopItem.count) then
 				TriggerClientEvent('ox_lib:notify', source, { title = "The requested amount of " .. itemData.label .. " is no longer in stock.", type = "error" })
 				goto continue
 			end
 
 			local newIndex = #validCartItems + 1
-			validCartItems[newIndex] = mappedCartItems[shopItem.name]
+			validCartItems[newIndex] = mappedCartItem
 			validCartItems[newIndex].inventoryIndex = i
 
-			totalPrice = totalPrice + (shopItem.price * mappedCartItems[shopItem.name].quantity)
+			totalPrice = totalPrice + (shopItem.price * mappedCartItem.quantity)
 		end
 
 		:: continue ::
@@ -144,7 +146,7 @@ lib.callback.register("EF-Shops:Server:PurchaseItems", function(source, purchase
 	for i = 1, #validCartItems do
 		local item = validCartItems[i]
 		local itemData = ITEMS[item.name]
-		local productData = PRODUCTS[shopData.shopItems][item.name]
+		local productData = PRODUCTS[shopData.shopItems][item.id]
 
 		if not itemData then
 			lib.print.error("Invalid item: " .. item.name .. " in shop: " .. shopType)
@@ -218,8 +220,8 @@ AddEventHandler('onResourceStart', function(resource)
 	if GetCurrentResourceName() ~= resource and "ox_inventory" ~= resource then return end
 
 	for productType, productData in pairs(PRODUCTS) do
-		for item, _ in pairs(productData) do
-			if not ITEMS[(string.find(item, "weapon_") and (item):upper()) or item] then
+		for _, item in pairs(productData) do
+			if not ITEMS[(string.find(item.name, "weapon_") and (item.name):upper()) or item.name] then
 				lib.print.error("Invalid Item: ", item, "in product table:", productType, "^7")
 				productData[item] = nil
 			end
@@ -235,11 +237,13 @@ AddEventHandler('onResourceStart', function(resource)
 		local shopProducts = {}
 		for item, data in pairs(PRODUCTS[shopData.shopItems]) do
 			shopProducts[#shopProducts + 1] = {
-				name = item,
+				id = tonumber(item),
+				name = data.name,
 				price = config.fluctuatePrices and (math.round(data.price * (math.random(80, 120) / 100))) or data.price or 0, -- Price fluctuation algorithm from ox_inventory https://github.com/overextended/ox_inventory/blob/e3a6b905a1b8bdbd3066d012522cf5993466d166/modules/shops/server.lua#L32
 				license = data.license,
-				info = data.info,
-				count = data.defaultStock
+				metadata = data.metadata,
+				count = data.defaultStock,
+				jobs = data.jobs
 			}
 		end
 

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -58,6 +58,7 @@ debugData([
 		action: "setShopItems",
 		data: [
 			{
+				id: 1,
 				name: "redwood",
 				category: "Redwood Wights Pack Long",
 				label: "Redwood Wights Pack Long",
@@ -67,6 +68,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/egochaser.png",
 			},
 			{
+				id: 2,
 				name: "egochaser",
 				category: "Food",
 				label: "Ego Chaser",
@@ -75,6 +77,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/egochaser.png",
 			},
 			{
+				id: 3,
 				name: "steak",
 				category: "Food",
 				label: "Steak",
@@ -82,6 +85,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/steak.png",
 			},
 			{
+				id: 4,
 				name: "sparklng water",
 				category: "Drink",
 				label: "Crystal Clear Sparkling Water",
@@ -91,6 +95,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/sparkling_water.png",
 			},
 			{
+				id: 5,
 				name: "spots watch",
 				category: "Accessory",
 				label: "Sports Watch",
@@ -101,6 +106,7 @@ debugData([
 				license: "accessory",
 			},
 			{
+				id: 6,
 				name: "gamng mouse",
 				category: "Electronics",
 				label: "Gaming Mouse",
@@ -110,6 +116,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/gaming_mouse.png",
 			},
 			{
+				id: 7,
 				name: "chocolte bar",
 				category: "Food",
 				label: "Deluxe Chocolate Bar",
@@ -119,6 +126,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/chocolate_bar.png",
 			},
 			{
+				id: 8,
 				name: "basebal cap",
 				category: "Clothing",
 				label: "Baseball Cap",
@@ -128,6 +136,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/baseball_cap.png",
 			},
 			{
+				id: 9,
 				name: "artisan cof2ee",
 				category: "Drink",
 				label: "Artisan Coffee Beans",
@@ -137,6 +146,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/artisan_coffee.png",
 			},
 			{
+				id: 10,
 				name: "vintage sunglsses",
 				category: "Accessory",
 				label: "Vintage Sunglasses",
@@ -146,6 +156,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/vintage_sunglasses.png",
 			},
 			{
+				id: 11,
 				name: "wireless headphnes",
 				category: "Electronics",
 				label: "Wireless Headphones",
@@ -155,6 +166,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/wireless_headphones.png",
 			},
 			{
+				id: 12,
 				name: "organic granola bar1",
 				category: "Food",
 				label: "Organic Granola Bars",
@@ -164,6 +176,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/organic_granola_bars.png",
 			},
 			{
+				id: 13,
 				name: "runnng shoes",
 				category: "Clothing",
 				label: "Running Shoes",
@@ -173,6 +186,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/running_shoes.png",
 			},
 			{
+				id: 14,
 				name: "e-reade",
 				category: "Electronics",
 				label: "E-Reader",
@@ -182,6 +196,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/e_reader.png",
 			},
 			{
+				id: 15,
 				name: "stek",
 				category: "Food",
 				label: "Steak",
@@ -189,6 +204,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/steak.png",
 			},
 			{
+				id: 16,
 				name: "sprkling water",
 				category: "Drink",
 				label: "Crystal Clear Sparkling Water",
@@ -198,6 +214,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/sparkling_water.png",
 			},
 			{
+				id: 17,
 				name: "sprts watch",
 				category: "Accessory",
 				label: "Sports Watch",
@@ -208,6 +225,7 @@ debugData([
 				license: "accessory",
 			},
 			{
+				id: 18,
 				name: "ga2mng mouse",
 				category: "Electronics",
 				label: "Gaming Mouse",
@@ -217,6 +235,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/gaming_mouse.png",
 			},
 			{
+				id: 19,
 				name: "chocoate bar",
 				category: "Food",
 				label: "Deluxe Chocolate Bar",
@@ -226,6 +245,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/chocolate_bar.png",
 			},
 			{
+				id: 20,
 				name: "baseall cap",
 				category: "Clothing",
 				label: "Baseball Cap",
@@ -235,6 +255,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/baseball_cap.png",
 			},
 			{
+				id: 21,
 				name: "artisan cofee",
 				category: "Drink",
 				label: "Artisan Coffee Beans",
@@ -244,6 +265,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/artisan_coffee.png",
 			},
 			{
+				id: 22,
 				name: "vintage sunlsses",
 				category: "Accessory",
 				label: "Vintage Sunglasses",
@@ -253,6 +275,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/vintage_sunglasses.png",
 			},
 			{
+				id: 23,
 				name: "wireless headphones",
 				category: "Electronics",
 				label: "Wireless Headphones",
@@ -262,6 +285,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/wireless_headphones.png",
 			},
 			{
+				id: 24,
 				name: "organic granola bars1",
 				category: "Food",
 				label: "Organic Granola Bars",
@@ -271,6 +295,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/organic_granola_bars.png",
 			},
 			{
+				id: 25,
 				name: "running shoes",
 				category: "Clothing",
 				label: "Running Shoes",
@@ -280,6 +305,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/running_shoes.png",
 			},
 			{
+				id: 26,
 				name: "e-reader",
 				category: "Electronics",
 				label: "E-Reader",
@@ -289,6 +315,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/e_reader.png",
 			},
 			{
+				id: 27,
 				name: "gourmet cheese",
 				category: "Food",
 				label: "Gourmet Cheese",
@@ -298,6 +325,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/gourmet_cheese.png",
 			},
 			{
+				id: 28,
 				name: "smartwatch",
 				category: "Electronics",
 				label: "Smartwatch",
@@ -307,6 +335,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/smartwatch.png",
 			},
 			{
+				id: 29,
 				name: "professional camera",
 				category: "Electronics",
 				label: "Professional Camera",
@@ -316,6 +345,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/professional_camera.png",
 			},
 			{
+				id: 30,
 				name: "yoga mat",
 				category: "Accessory",
 				label: "Yoga Mat",
@@ -325,6 +355,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/yoga_mat.png",
 			},
 			{
+				id: 31,
 				name: "bluetooth speaker",
 				category: "Electronics",
 				label: "Bluetooth Speaker",
@@ -334,6 +365,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/bluetooth_speaker.png",
 			},
 			{
+				id: 32,
 				name: "backpack",
 				category: "Accessory",
 				label: "Backpack",
@@ -343,6 +375,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/backpack.png",
 			},
 			{
+				id: 33,
 				name: "redwoo",
 				category: "Food",
 				label: "Redwood",
@@ -351,6 +384,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/redwood.png",
 			},
 			{
+				id: 34,
 				name: "running sh3oes",
 				category: "Clothing",
 				label: "Running Shoes",
@@ -360,6 +394,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/running_shoes.png",
 			},
 			{
+				id: 35,
 				name: "e-read2er",
 				category: "Electronics",
 				label: "E-Reader",
@@ -369,6 +404,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/e_reader.png",
 			},
 			{
+				id: 36,
 				name: "gourm1et cheese",
 				category: "Food",
 				label: "Gourmet Cheese",
@@ -378,6 +414,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/gourmet_cheese.png",
 			},
 			{
+				id: 37,
 				name: "sm3artwatch",
 				category: "Electronics",
 				label: "Smartwatch",
@@ -387,6 +424,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/smartwatch.png",
 			},
 			{
+				id: 38,
 				name: "profe1ssional camera",
 				category: "Electronics",
 				label: "Professional Camera",
@@ -396,6 +434,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/professional_camera.png",
 			},
 			{
+				id: 39,
 				name: "yoga 3mat",
 				category: "Accessory",
 				label: "Yoga Mat",
@@ -405,6 +444,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/yoga_mat.png",
 			},
 			{
+				id: 40,
 				name: "bluetoot1h speaker",
 				category: "Electronics",
 				label: "Bluetooth Speaker",
@@ -414,6 +454,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/bluetooth_speaker.png",
 			},
 			{
+				id: 41,
 				name: "backp3ack",
 				category: "Accessory",
 				label: "Backpack",
@@ -423,6 +464,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/backpack.png",
 			},
 			{
+				id: 42,
 				name: "blue1toot1h speaker",
 				category: "Electronics",
 				label: "Bluetooth Speaker",
@@ -432,6 +474,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/bluetooth_speaker.png",
 			},
 			{
+				id: 43,
 				name: "bluetoo2t1h speaker",
 				category: "Electronics",
 				label: "Bluetooth Speaker",
@@ -441,6 +484,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/bluetooth_speaker.png",
 			},
 			{
+				id: 44,
 				name: "bluetoot15h speaker",
 				category: "Electronics",
 				label: "Bluetooth Speaker",
@@ -450,6 +494,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/bluetooth_speaker.png",
 			},
 			{
+				id: 45,
 				name: "bluetoot1h spe6aker",
 				category: "Electronics",
 				label: "Bluetooth Speaker",
@@ -459,6 +504,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/bluetooth_speaker.png",
 			},
 			{
+				id: 46,
 				name: "bluetoot1h spe41aker",
 				category: "Electronics",
 				label: "Bluetooth Speaker",
@@ -468,6 +514,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/bluetooth_speaker.png",
 			},
 			{
+				id: 47,
 				name: "blueto21ot1h speaker",
 				category: "Electronics",
 				label: "Bluetooth Speaker",
@@ -477,6 +524,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/bluetooth_speaker.png",
 			},
 			{
+				id: 48,
 				name: "blueto12ot1h speaker",
 				category: "Electronics",
 				label: "Bluetooth Speaker",
@@ -486,6 +534,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/bluetooth_speaker.png",
 			},
 			{
+				id: 49,
 				name: "bluetoo32t1h speaker",
 				category: "Electronics",
 				label: "Bluetooth Speaker",
@@ -495,6 +544,7 @@ debugData([
 				imagePath: "https://files.jellyton.me/ShareX/2024/02/bluetooth_speaker.png",
 			},
 			{
+				id: 50,
 				name: "blu1etoot1h speaker",
 				category: "Electronics",
 				label: "Bluetooth Speaker",

--- a/web/src/components/Cart.tsx
+++ b/web/src/components/Cart.tsx
@@ -28,19 +28,20 @@ function PaymentButtons() {
 	const [awaitingPaymentCash, setAwaitingPaymentCash] = useState(false);
 	const [awaitingPaymentCard, setAwaitingPaymentCard] = useState(false);
 
-	const canAffordCash = CartItems?.reduce((acc, item) => acc + getShopItemData(item.name).price * item.quantity, 0) <= Money.Cash;
-	const canAffordCard = CartItems?.reduce((acc, item) => acc + getShopItemData(item.name).price * item.quantity, 0) <= Money.Bank;
+	const canAffordCash = CartItems?.reduce((acc, item) => acc + getShopItemData(item.id).price * item.quantity, 0) <= Money.Cash;
+	const canAffordCard = CartItems?.reduce((acc, item) => acc + getShopItemData(item.id).price * item.quantity, 0) <= Money.Bank;
 	const overWeight = Weight + cartWeight > MaxWeight;
 
 	function finishPurchase() {
 		// Create a new array with updated quantities
 		const updatedShopItems = ShopItems.map((shopItem) => {
-			const cartItem = CartItems.find((item) => item.name === shopItem.name);
+			const cartItem = CartItems.find((item) => item.id === shopItem.id);
 			if (cartItem) {
-				return { ...shopItem, count: shopItem.count - cartItem.quantity };
-			} else {
-				return shopItem;
+				if (shopItem.count !== undefined) {
+					return { ...shopItem, count: shopItem.count - cartItem.quantity };
+				}
 			}
+			return shopItem;
 		});
 
 		// Update the state
@@ -120,12 +121,12 @@ export default function Cart() {
 	const { Money, Weight, MaxWeight } = useStoreSelf();
 
 	const currentCartItems = CartItems?.map((item) => {
-		const storeItem = getShopItemData(item.name);
+		const storeItem = getShopItemData(item.id);
 		var price = storeItem.price;
 		var title = <Title order={5}>{storeItem.label}</Title>;
 
 		return (
-			<div className="mx-1 p-2" key={item.name}>
+			<div className="mx-1 p-2" key={item.id}>
 				<Group w="100%" justify="space-between" wrap="nowrap">
 					{title}
 					<Group justify="flex-end" ml="auto">
@@ -184,7 +185,7 @@ export default function Cart() {
 								color="red"
 								variant="light"
 								onClick={() => {
-									removeItemFromCart(item.name, null, true);
+									removeItemFromCart(item.id, null, true);
 								}}
 							>
 								<FontAwesomeIcon icon={faXmark} />
@@ -208,7 +209,7 @@ export default function Cart() {
 					<Text fw={700} fz={19} component="span">
 						{"Total: "}
 					</Text>
-					${formatMoney(CartItems?.reduce((acc, item) => acc + getShopItemData(item.name).price * item.quantity, 0) || 0)}
+					${formatMoney(CartItems?.reduce((acc, item) => acc + getShopItemData(item.id).price * item.quantity, 0) || 0)}
 				</Text>
 			</div>
 			<div className={`flex h-0 grow flex-col gap-3 ${CartItems?.length > 0 && "overflow-y-auto"}`}>

--- a/web/src/components/ItemCard.tsx
+++ b/web/src/components/ItemCard.tsx
@@ -12,7 +12,7 @@ export default function ItemCard(props: { item: ShopItem }) {
 	const canNotAfford = cartValue + item.price > Money.Cash && cartValue + item.price > Money.Bank;
 	const overWeight = Weight + cartWeight + item.weight > MaxWeight;
 	const currentItemQuantityInCart = CartItems.reduce((total, cartItem) => {
-		return cartItem.name === item.name ? total + cartItem.quantity : total;
+		return cartItem.id === item.id ? total + cartItem.quantity : total;
 	}, 0);
 	const inStock = !item.count || item.count > currentItemQuantityInCart;
 	const hasLicense = (!item.license && true) || (Licenses && Licenses[item.license]) == true;

--- a/web/src/components/ItemCard.tsx
+++ b/web/src/components/ItemCard.tsx
@@ -14,8 +14,8 @@ export default function ItemCard(props: { item: ShopItem }) {
 	const currentItemQuantityInCart = CartItems.reduce((total, cartItem) => {
 		return cartItem.id === item.id ? total + cartItem.quantity : total;
 	}, 0);
-	const inStock = !item.count || item.count > currentItemQuantityInCart;
-	const hasLicense = (!item.license && true) || (Licenses && Licenses[item.license]) == true;
+	const inStock = item.count === undefined || item.count > currentItemQuantityInCart;
+	const hasLicense = (!item.license && true) || (Licenses && Licenses[item.license]) === true;
 	const hasCorrectGrade = !item.jobs || (item.jobs && item.jobs[Job.name] && item.jobs[Job.name] <= Job.grade);
 
 	const disabled = canNotAfford || overWeight || !inStock || !hasLicense || !hasCorrectGrade;
@@ -24,13 +24,23 @@ export default function ItemCard(props: { item: ShopItem }) {
 
 	return (
 		<Tooltip
-			label={(!hasLicense && "You need a " + item.license + " license to purchase this item.") || (canNotAfford && "You cannot afford this item.") || (overWeight && "You cannot carry this item.")}
-			disabled={!canNotAfford && !overWeight}
+			label={
+				(!hasLicense && "You need a " + item.license + " license to purchase this item.") ||
+				(canNotAfford && "You cannot afford this item.") ||
+				(overWeight && "You cannot carry this item.") ||
+				(!inStock && "This item is out of stock.") ||
+				(!hasCorrectGrade && "You don't have the correct job and rank to purchase this item")
+			}
+			disabled={!canNotAfford && !overWeight && hasLicense && hasCorrectGrade && inStock}
 		>
 			<Grid.Col span={1} className="grow">
 				<div
 					ref={ref}
-					className={`flex h-full flex-col justify-between rounded-sm bg-neutral-800 p-2 transition-all ${!disabled ? "hover:bg-neutral-600/20" : ""} ${disabled ? "bg-opacity-20" : "bg-opacity-80"} ${disabled ? "cursor-not-allowed" : "cursor-pointer"} ${disabled ? "grayscale" : ""} ${hovered && !disabled ? "scale-105 shadow-md" : ""}`}
+					className={`flex h-full flex-col justify-between rounded-sm bg-neutral-800 p-2 transition-all ${!disabled ? "hover:bg-neutral-600/20" : ""} ${
+						disabled ? "bg-opacity-20" : "bg-opacity-80"
+					} ${disabled ? "cursor-not-allowed" : "cursor-pointer"} ${disabled ? "grayscale" : ""} ${
+						hovered && !disabled ? "scale-105 shadow-md" : ""
+					}`}
 					onClick={() => {
 						if (disabled) return;
 						addItemToCart(item);
@@ -38,7 +48,7 @@ export default function ItemCard(props: { item: ShopItem }) {
 				>
 					<div className="mx-auto flex w-full flex-nowrap justify-between px-1">
 						<p className="text-lg font-semibold">${item.price}</p>
-						{item.count && <p className="text-lg font-semibold">{item.count}x</p>}
+						{item.count !== undefined && <p className="text-lg font-semibold">{item.count}x</p>}
 					</div>
 					<div className="m-auto flex h-[80%]">
 						<img

--- a/web/src/components/ShopGrid.tsx
+++ b/web/src/components/ShopGrid.tsx
@@ -7,7 +7,7 @@ function ShopTab(props: { tab: string }) {
 	const { tab } = props;
 	const { categorizedItems } = useStoreShop();
 
-	const jobCards = useMemo(() => categorizedItems[tab]?.map((item) => <ItemCard key={item.name} item={item} />), [categorizedItems, tab]);
+	const itemCards = useMemo(() => categorizedItems[tab]?.map((item) => <ItemCard key={item.id} item={item} />), [categorizedItems, tab]);
 
 	return (
 		<ScrollArea h="100%" scrollbarSize={4}>
@@ -21,7 +21,7 @@ function ShopTab(props: { tab: string }) {
 					inner: { height: "100%" },
 				}}
 			>
-				{jobCards}
+				{itemCards}
 			</Grid>
 		</ScrollArea>
 	);

--- a/web/src/stores/ShopStore.ts
+++ b/web/src/stores/ShopStore.ts
@@ -11,9 +11,9 @@ type ShopItems = {
 	setCurrentShop: (shop: Shop) => void;
 	setShopItems: (items: ShopItem[]) => void;
 	addItemToCart: (item: ShopItem, amount?: number) => void;
-	removeItemFromCart: (itemName: string, amount?: number, removeAll?: boolean) => void;
+	removeItemFromCart: (itemId: number, amount?: number, removeAll?: boolean) => void;
 	clearCart: () => void;
-	getShopItemData: (itemName: string) => ShopItem | undefined;
+	getShopItemData: (itemId: number) => ShopItem | undefined;
 };
 
 export const useStoreShop = create<ShopItems>((set, get) => ({
@@ -50,7 +50,7 @@ export const useStoreShop = create<ShopItems>((set, get) => ({
 
 	addItemToCart: (item: ShopItem, amount: number) => {
 		const { CartItems, cartWeight, cartValue } = get();
-		const existingItemIndex = CartItems.findIndex((cartItem) => cartItem.name === item.name);
+		const existingItemIndex = CartItems.findIndex((cartItem) => cartItem.id === item.id);
 
 		let newCartWeight = cartWeight + item.weight; // Update cart weight
 		let newCartValue = cartValue + item.price; // Update cart value
@@ -65,7 +65,7 @@ export const useStoreShop = create<ShopItems>((set, get) => ({
 			}));
 		} else {
 			// Item not in cart, add new item
-			const newItem = { name: item.name, quantity: amount || 1, weight: item.weight, price: item.price };
+			const newItem = { id: item.id, name: item.name, quantity: amount || 1, weight: item.weight, price: item.price };
 			set(() => ({
 				CartItems: [...CartItems, newItem],
 				cartWeight: newCartWeight,
@@ -74,14 +74,15 @@ export const useStoreShop = create<ShopItems>((set, get) => ({
 		}
 	},
 
-	removeItemFromCart: (itemName: string, amount?: number, removeAll: boolean = false) => {
+	removeItemFromCart: (itemId: number, amount?: number, removeAll: boolean = false) => {
 		const { CartItems, cartWeight, cartValue, getShopItemData } = get();
-		const existingItemIndex = CartItems.findIndex((cartItem) => cartItem.name === itemName);
+		const existingItemIndex = CartItems.findIndex((cartItem) => cartItem.id === itemId);
 
 		if (existingItemIndex >= 0) {
 			const existingItem = CartItems[existingItemIndex];
-			let itemWeightReduction = getShopItemData(existingItem.name).weight * (removeAll ? existingItem.quantity : amount || 1);
-			let itemValueReduction = getShopItemData(existingItem.name).price * (removeAll ? existingItem.quantity : amount || 1);
+			const shopItem = getShopItemData(existingItem.id);
+			let itemWeightReduction = shopItem.weight * (removeAll ? existingItem.quantity : amount || 1);
+			let itemValueReduction = shopItem.price * (removeAll ? existingItem.quantity : amount || 1);
 
 			if (existingItem.quantity > 1 && !removeAll) {
 				// Decrease quantity by 1, update weight and value
@@ -111,10 +112,10 @@ export const useStoreShop = create<ShopItems>((set, get) => ({
 		}));
 	},
 
-	getShopItemData: (itemName: string) => {
+	getShopItemData: (itemId: number) => {
 		const { ShopItems } = get();
 		if (ShopItems) {
-			return ShopItems.find((item) => item.name === itemName);
+			return ShopItems.find((item) => item.id === itemId);
 		}
 		return undefined; // Return undefined if the item is not found or if ShopItems is null
 	},

--- a/web/src/stores/ShopStore.ts
+++ b/web/src/stores/ShopStore.ts
@@ -52,12 +52,14 @@ export const useStoreShop = create<ShopItems>((set, get) => ({
 		const { CartItems, cartWeight, cartValue } = get();
 		const existingItemIndex = CartItems.findIndex((cartItem) => cartItem.id === item.id);
 
-		let newCartWeight = cartWeight + item.weight; // Update cart weight
-		let newCartValue = cartValue + item.price; // Update cart value
+		let newCartWeight = cartWeight + item.weight * (amount || 1); // Update cart weight
+		let newCartValue = cartValue + item.price * (amount || 1); // Update cart value
 
 		if (existingItemIndex >= 0) {
 			// Item already exists in cart, increase quantity and update weight and value
-			const updatedCartItems = CartItems.map((cartItem, index) => (index === existingItemIndex ? { ...cartItem, quantity: cartItem.quantity + (amount || 1) } : cartItem));
+			const updatedCartItems = CartItems.map((cartItem, index) => 
+				index === existingItemIndex ? { ...cartItem, quantity: cartItem.quantity + (amount || 1) } : cartItem
+			);
 			set(() => ({
 				CartItems: updatedCartItems,
 				cartWeight: newCartWeight,
@@ -85,8 +87,10 @@ export const useStoreShop = create<ShopItems>((set, get) => ({
 			let itemValueReduction = shopItem.price * (removeAll ? existingItem.quantity : amount || 1);
 
 			if (existingItem.quantity > 1 && !removeAll) {
-				// Decrease quantity by 1, update weight and value
-				const updatedCartItems = CartItems.map((cartItem, index) => (index === existingItemIndex ? { ...cartItem, quantity: cartItem.quantity - (amount || 1) } : cartItem));
+				// Decrease quantity, update weight and value
+				const updatedCartItems = CartItems.map((cartItem, index) => 
+					index === existingItemIndex ? { ...cartItem, quantity: cartItem.quantity - (amount || 1) } : cartItem
+				);
 				set(() => ({
 					CartItems: updatedCartItems,
 					cartWeight: cartWeight - itemWeightReduction,

--- a/web/src/types/ShopItem.ts
+++ b/web/src/types/ShopItem.ts
@@ -5,6 +5,7 @@ export type Shop = {
 };
 
 export type ShopItem = {
+	id: number;
 	name: string;
 	label: string;
 	price: number;
@@ -18,6 +19,7 @@ export type ShopItem = {
 };
 
 export type CartItem = {
+	id: number;
 	name: string;
 	quantity: number;
 };

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],
+  base: './',
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
By using item Ids generated at runtime we can have multiple slots with the same item. This enables stores to stock multiple items with unique metadata such as scratch cards (my main motivation for this) or weapons with attachments etc.

Change log
- Also adds support for metadata `label`, `weight`, and `imageurl` overrides.
- Fixes issues with tooltips for disabled items including out of stock reason
- Moves job check to before money removal to prevent users from paying for items and getting nothing
- Shows quantity where appropriate in both dev and live
- Abstracts quantity check to function and improves check to block on overweight/no money
- Dynamically updates money, job, licenses, and weight by watching for appropriate events
- Fixes issue with build not specifying correct basepath
- Fixes issue with non-ped models not being removed when outside of `lib.points` zone
- Removes some linter warnings about using non expanded values (really only affects scripts using OAL as this doesn't have vector expansion)