### PR TITLE
feat(server/sv_main): add slot data to trigger metadata generation

### DIFF
--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -181,7 +181,8 @@ lib.callback.register("EF-Shops:Server:PurchaseItems", function(source, purchase
 			goto continue
 		end
 
-		local success, response = ox_inventory:AddItem(source, item.name, item.quantity, productData.metadata)
+		local freeSlot = exports.ox_inventory:GetEmptySlot(source)
+		local success, response = ox_inventory:AddItem(source, item.name, item.quantity, productData.metadata, freeSlot)
 		if success then
 			if shop.inventory[item.inventoryIndex].count then
 				shop.inventory[item.inventoryIndex].count = shop.inventory[item.inventoryIndex].count - item.quantity


### PR DESCRIPTION
ox_inventory doesn't trigger metadata creation for items unless a slot is specified. This corrects that issue.